### PR TITLE
Rename app from "Web" to "Syosset"

### DIFF
--- a/app/views/partials/_footer.haml
+++ b/app/views/partials/_footer.haml
@@ -13,5 +13,5 @@
         %a{:href => "https://www.facebook.com/syosseths"}
           %i.fa.fa-facebook
       %li
-        %a{:href => "https://github.com/Syosset/Web"}
+        %a{:href => "https://github.com/Syosset/syosset"}
           %i.fa.fa-github

--- a/config/application.rb
+++ b/config/application.rb
@@ -16,7 +16,7 @@ require "sprockets/railtie"
 # you've limited to :test, :development, or :production.
 Bundler.require(*Rails.groups)
 
-module Web
+module Syosset
   class Application < Rails::Application
     # Initialize configuration defaults for originally generated Rails version.
     config.load_defaults 5.1

--- a/config/cable.yml
+++ b/config/cable.yml
@@ -7,4 +7,4 @@ test:
 production:
   adapter: redis
   url: redis://localhost:6379/1
-  channel_prefix: web_production
+  channel_prefix: syosset_production

--- a/config/initializers/peek.rb
+++ b/config/initializers/peek.rb
@@ -6,7 +6,7 @@ module Peek::Views
   end
 end
 
-Peek.into Peek::Views::Git, nwo: "Syosset/Web", sha: ENV["GIT_REV"]
+Peek.into Peek::Views::Git, nwo: "Syosset/syosset", sha: ENV["GIT_REV"]
 Peek.into Peek::Views::Admin
 Peek.into Peek::Views::Host, host: ENV["HOSTNAME"]
 Peek.into Peek::Views::Redis

--- a/config/initializers/redis.rb
+++ b/config/initializers/redis.rb
@@ -1,5 +1,5 @@
 $redis = Redis.new(url: ENV["REDIS_URL"])
-Web::Application.configure do
+Syosset::Application.configure do
   config.peek.adapter = :redis, {
       client: $redis
     }

--- a/config/mongoid.yml
+++ b/config/mongoid.yml
@@ -9,7 +9,7 @@ development:
     default:
       # Defines the name of the default database that Mongoid can connect to.
       # (required).
-      database: web_development
+      database: syosset_development
       # Provides the hosts the default client can connect to. Must be an array
       # of host:port pairs. (required)
       hosts:

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "web",
+  "name": "syosset",
   "private": true,
   "dependencies": {
     "bootstrap-sass": "^3.3.7",

--- a/spec/config/mongoid.yml
+++ b/spec/config/mongoid.yml
@@ -1,7 +1,7 @@
 test:
   clients:
     default:
-      database: web_test
+      database: syosset_test
       hosts:
         - localhost:27017
       options:


### PR DESCRIPTION
We should also rename the repository to "syosset" to match.